### PR TITLE
Util for mapping sites to svectors

### DIFF
--- a/src/MuJoCo.jl
+++ b/src/MuJoCo.jl
@@ -20,6 +20,7 @@ export
     jl_disabled,
     jl_name2id,
     jl_id2name,
+    siteSA,
 
     # Core
     MJCore,

--- a/src/jlmujoco.jl
+++ b/src/jlmujoco.jl
@@ -4,3 +4,6 @@ jl_id2name(m::jlModel, objtype, id::Integer) = MJCore.mj_id2name(m, objtype, Int
 jl_enabled(m::jlModel, flag::MJCore.mjtEnableBit) = _flagtest(m.opt.enableflags, flag)
 jl_disabled(m::jlModel, flag::Union{Integer, MJCore.mjtDisableBit}) = _flagtest(m.opt.disableflags, flag)
 _flagtest(flags, flag) = Integer(flags) & Integer(flag) == Integer(flag)
+
+@propagate_inbounds _site(site)::SVector{3,Float64} = SA_F64[site[1], site[2], site[3]]
+@propagate_inbounds _site(sites, id)::SVector{3,Float64} = SA_F64[sites[1,id], sites[2,id], sites[3,id]]

--- a/src/jlmujoco.jl
+++ b/src/jlmujoco.jl
@@ -5,5 +5,5 @@ jl_enabled(m::jlModel, flag::MJCore.mjtEnableBit) = _flagtest(m.opt.enableflags,
 jl_disabled(m::jlModel, flag::Union{Integer, MJCore.mjtDisableBit}) = _flagtest(m.opt.disableflags, flag)
 _flagtest(flags, flag) = Integer(flags) & Integer(flag) == Integer(flag)
 
-@propagate_inbounds _site(site)::SVector{3,Float64} = SA_F64[site[1], site[2], site[3]]
-@propagate_inbounds _site(sites, id)::SVector{3,Float64} = SA_F64[sites[1,id], sites[2,id], sites[3,id]]
+Base.@propagate_inbounds siteSA(site)::SVector{3,Float64} = SA_F64[site[1], site[2], site[3]]
+Base.@propagate_inbounds siteSA(sites, id)::SVector{3,Float64} = SA_F64[sites[1,id], sites[2,id], sites[3,id]]


### PR DESCRIPTION
maps a matrix (ie site_xpos) or a vector (site_xpos saved elsewhere) to a SVector{3, Float64}.

Useful for grabbing a lot of sites from a model for obs or rewards.